### PR TITLE
Fix agent data isolation — filter MCP tools by owner_id

### DIFF
--- a/backend/app/agent/nodes.py
+++ b/backend/app/agent/nodes.py
@@ -16,7 +16,15 @@ def create_agent_node(llm: ChatLiteLLM, tools: list):
 
     async def agent_node(state: AgentState) -> dict:
         """Call the LLM with conversation history and available tools."""
-        messages = [SystemMessage(content=SYSTEM_PROMPT)] + state["messages"]
+        user_id = state.get("user_id", "")
+        system_content = SYSTEM_PROMPT
+        if user_id:
+            system_content += (
+                f"\n\nIMPORTANT: The current user's ID is '{user_id}'. "
+                "You MUST pass this as the 'user_id' parameter in EVERY tool call "
+                "to ensure data isolation. Never omit the user_id parameter."
+            )
+        messages = [SystemMessage(content=system_content)] + state["messages"]
         response = await llm_with_tools.ainvoke(messages)
         return {"messages": [response]}
 

--- a/backend/app/agent/state.py
+++ b/backend/app/agent/state.py
@@ -14,3 +14,4 @@ class AgentState(TypedDict):
     """
 
     messages: Annotated[list[AnyMessage], operator.add]
+    user_id: str

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -100,7 +100,7 @@ async def chat(
                 new_messages: list = [user_msg]
 
                 async for mode, chunk in agent.astream(
-                    {"messages": history},
+                    {"messages": history, "user_id": str(user_id)},
                     stream_mode=["messages", "updates"],
                 ):
                     if await request.is_disconnected():

--- a/backend/app/mcp/tools/analytics_tools.py
+++ b/backend/app/mcp/tools/analytics_tools.py
@@ -49,6 +49,7 @@ async def booking_analytics(
     period_start: str | None = None,
     period_end: str | None = None,
     metric: str = "summary",
+    user_id: str | None = None,
 ) -> dict:
     """Analyze booking performance: occupancy, revenue, and trends.
 
@@ -58,6 +59,7 @@ async def booking_analytics(
         period_start: Start date for analysis (YYYY-MM-DD, defaults to 30 days ago)
         period_end: End date for analysis (YYYY-MM-DD, defaults to today)
         metric: Type of analysis — "summary" (all), "occupancy", "revenue", or "trends"
+        user_id: UUID of the current user (filters to only their properties)
 
     Returns:
         Dict with analytics results based on the requested metric.
@@ -81,6 +83,8 @@ async def booking_analytics(
         async with session_factory() as session:
             # Fetch properties
             prop_query = select(Property)
+            if user_id:
+                prop_query = prop_query.where(Property.owner_id == uuid.UUID(user_id))
             if property_name:
                 prop_query = prop_query.where(Property.name.ilike(f"%{property_name}%"))
             if property_id:

--- a/backend/app/mcp/tools/notification_tools.py
+++ b/backend/app/mcp/tools/notification_tools.py
@@ -92,6 +92,7 @@ async def send_notification(
     guest_email: str | None = None,
     booking_id: str | None = None,
     custom_message: str | None = None,
+    user_id: str | None = None,
 ) -> dict:
     """Compose and send a notification to a guest using a template.
 
@@ -103,6 +104,7 @@ async def send_notification(
         guest_email: Direct email address (alternative to guest_id)
         booking_id: UUID of the related booking (used to fill template variables)
         custom_message: Custom message body (required for "custom" template)
+        user_id: UUID of the current user (verifies booking ownership)
 
     Returns:
         Dict with composed notification details (recipient, subject, body) and status.
@@ -160,6 +162,8 @@ async def send_notification(
                     return {"error": f"Invalid booking_id: '{booking_id}'", "status": "failed"}
 
                 if booking is None:
+                    return {"error": f"Booking not found: '{booking_id}'", "status": "failed"}
+                if user_id and booking.property and str(booking.property.owner_id) != user_id:
                     return {"error": f"Booking not found: '{booking_id}'", "status": "failed"}
                 prop = booking.property
 


### PR DESCRIPTION
## Summary
- MCP tools returned data from ALL users because they had no user context — security/data integrity issue
- Agent now receives `user_id` via AgentState and passes it to every MCP tool call
- All 7 MCP tools now filter queries by `Property.owner_id`

## Changes
- `backend/app/agent/state.py` — Add `user_id: str` to AgentState
- `backend/app/api/v1/chat.py` — Pass `user_id` to agent invocation
- `backend/app/agent/nodes.py` — Inject `user_id` into system prompt
- `backend/app/mcp/tools/booking_tools.py` — Filter booking_search, booking_create, booking_update by owner_id
- `backend/app/mcp/tools/property_tools.py` — Filter _resolve_property and property_manage by owner_id
- `backend/app/mcp/tools/analytics_tools.py` — Filter booking_analytics by owner_id
- `backend/app/mcp/tools/guest_tools.py` — Filter guest_lookup to guests with bookings at user's properties
- `backend/app/mcp/tools/notification_tools.py` — Verify booking ownership in send_notification

## Testing
- [x] Backend + MCP start without errors
- [x] Health endpoints return healthy
- [x] Synced and tested on EC2 dev environment
- [x] Agent correctly passes user_id to tool calls
- [x] booking_analytics returns only user's properties

## Known Issue
- No `property_list` MCP tool exists — agent falls back to `booking_analytics` to list properties (tracked separately)

## Deploy Notes
- Backend-only change — backend + MCP redeploy

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)